### PR TITLE
Add a header "Accept: application/json" to requests

### DIFF
--- a/json_request.js
+++ b/json_request.js
@@ -1,6 +1,5 @@
 chrome.webRequest.onBeforeSendHeaders.addListener(
 	function(details) {
-		console.log("Cat intercepted: " + details.requestHeaders);
 		details.requestHeaders.push({name:"Accept",value:"application/json"});
 		return {requestHeaders: details.requestHeaders};
 	},

--- a/json_request.js
+++ b/json_request.js
@@ -1,0 +1,10 @@
+chrome.webRequest.onBeforeSendHeaders.addListener(
+	function(details) {
+		console.log("Cat intercepted: " + details.requestHeaders);
+		details.requestHeaders.push({name:"Accept",value:"application/json"});
+		return {requestHeaders: details.requestHeaders};
+	},
+	{urls: ["*://*.ft.com/__health"]},
+	["requestHeaders", "blocking"]
+);
+

--- a/manifest.json
+++ b/manifest.json
@@ -7,9 +7,17 @@
       "js": [ "mustache.min.js", "content.js" ],
       "matches": [ "*://*/health", "*://*/__health", "*://*/*/health", "*://*/*/__health", "*://*/*/health?*", "*://*/*/__health?*" ],
       "run_at": "document_end"
-   } ],
+   }],
    "icons": {
       "128": "icon_128.png"
    },
-   "web_accessible_resources": [ "template.html", "format.js" ]
+   "web_accessible_resources": [ "template.html", "format.js" ],
+    "background": {
+    "scripts": ["json_request.js"]
+   },
+   "permissions": [
+          "webRequest",
+	  "webRequestBlocking",
+          "*://*.ft.com/__health"
+        ]
 }


### PR DESCRIPTION
The healthcheck now accepts text/html and renders out human readable
pages. This does not work with the extension as it excpects JSON out by
default. In order to satisfy both use cases: those with extension and without, we can
always specifically request "application/json".